### PR TITLE
Update Dependabot schedule to monthly and adjust lint-build workflow …

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 10
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     versioning-strategy: increase

--- a/.github/workflows/lint-build.yml
+++ b/.github/workflows/lint-build.yml
@@ -41,9 +41,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
+        # Only test the production environment we deploy (Linux / Node 22).
+        # Reintroduce macOS/Windows or other Node versions later if needed.
+        os: [ubuntu-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [20.x, 22.x]
+        node-version: [22.x]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
…to target only Ubuntu with Node 22